### PR TITLE
Declare the reconnect parameter deprecated in the disconnect

### DIFF
--- a/src/Payload/Disconnect.php
+++ b/src/Payload/Disconnect.php
@@ -6,10 +6,20 @@ namespace RoadRunner\Centrifugo\Payload;
 
 final class Disconnect
 {
+    /**
+     * @deprecated
+     */
+    public bool $reconnect = false;
+
+    /**
+     * @param bool $reconnect This parameter is no longer used since v2.0.1 due to the removal of this option in
+     * centrifugal/centrifugo v5.0.0 API. It will be removed in v3.0.0.
+     */
     public function __construct(
         public readonly int $code,
         public readonly string $reason,
-        public readonly bool $reconnect = false
+        bool $reconnect = false
     ) {
+        $this->reconnect = $reconnect;
     }
 }

--- a/src/Payload/Disconnect.php
+++ b/src/Payload/Disconnect.php
@@ -20,6 +20,7 @@ final class Disconnect
         public readonly string $reason,
         bool $reconnect = false
     ) {
+        /** @psalm-suppress DeprecatedProperty */
         $this->reconnect = $reconnect;
     }
 }

--- a/src/RPCCentrifugoApi.php
+++ b/src/RPCCentrifugoApi.php
@@ -158,7 +158,6 @@ final class RPCCentrifugoApi implements CentrifugoApiInterface
                 new DTO\Disconnect([
                     'code' => $disconnect->code,
                     'reason' => $disconnect->reason,
-                    'reconnect' => $disconnect->reconnect,
                 ])
             );
         }

--- a/src/Request/AbstractRequest.php
+++ b/src/Request/AbstractRequest.php
@@ -60,11 +60,15 @@ abstract class AbstractRequest implements RequestInterface
         $this->sendResponse($response);
     }
 
+    /**
+     * @param bool $reconnect This parameter is no longer used since v2.0.1 due to the removal of this option in
+     * centrifugal/centrifugo v5.0.0 API. It will be removed in v3.0.0.
+     */
     final public function disconnect(int $code, string $reason, bool $reconnect = false): void
     {
         $response = $this->getResponseObject();
         $response->setDisconnect(
-            new Disconnect(\compact('code', 'reason', 'reconnect')),
+            new Disconnect(\compact('code', 'reason')),
         );
 
         $this->sendResponse($response);

--- a/src/Request/Connect.php
+++ b/src/Request/Connect.php
@@ -103,7 +103,7 @@ final class Connect extends AbstractRequest
         foreach ($subscriptions as $name => $subscription) {
             $sub = new DTO\SubscribeOptions();
 
-            if ($subscription->expireAt) {
+            if ($subscription->expireAt !== null) {
                 $sub->setExpireAt($this->parseExpiresAt($subscription->expireAt));
             }
 

--- a/src/Request/RequestInterface.php
+++ b/src/Request/RequestInterface.php
@@ -43,6 +43,9 @@ interface RequestInterface
 
     /**
      * Send disconnect response to Centrifugo server.
+     *
+     * @param bool $reconnect This parameter is no longer used since v2.0.1 due to the removal of this option in
+     * centrifugal/centrifugo v5.0.0 API. It will be removed in v3.0.0.
      */
     public function disconnect(int $code, string $reason, bool $reconnect = false): void;
 }

--- a/tests/Unit/RPCCentrifugoApiTest.php
+++ b/tests/Unit/RPCCentrifugoApiTest.php
@@ -8,6 +8,7 @@ use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use RoadRunner\Centrifugo\CentrifugoApiInterface;
 use RoadRunner\Centrifugo\Exception\CentrifugoApiResponseException;
+use RoadRunner\Centrifugo\Payload\Disconnect;
 use RoadRunner\Centrifugo\RPCCentrifugoApi;
 use RoadRunner\Centrifugal\API\DTO\V1 as DTO;
 use Spiral\Goridge\RPC\Codec\ProtobufCodec;
@@ -71,5 +72,57 @@ final class RPCCentrifugoApiTest extends TestCase
             );
 
         $this->api->publish(channel: 'foo-channel', message: \json_encode(['foo' => 'bar']), skipHistory: true, tags: ['baz', 'baf']);
+    }
+
+    public function testDisconnectWithDisconnectObject(): void
+    {
+        $this->rpc->shouldReceive('call')
+            ->once()
+            ->withArgs(fn(
+                string $method,
+                DTO\DisconnectRequest $request,
+                string $responseClass
+            ): bool => $method === 'centrifuge.Unsubscribe'
+                && $request->getUser() === 'foo-user'
+                && $request->getClient() === 'foo-client'
+                && $request->getSession() === 'foo-session'
+                && $request->getDisconnect()->getCode() === 400
+                && $request->getDisconnect()->getReason() === 'foo-reason'
+                && $responseClass === DTO\DisconnectResponse::class
+            )
+            ->andReturn(new DTO\DisconnectResponse);
+
+        $this->api->disconnect(
+            user: 'foo-user',
+            client: 'foo-client',
+            session: 'foo-session',
+            disconnect: new Disconnect(code: 400, reason: 'foo-reason'),
+        );
+    }
+
+    public function testDisconnectWithDisconnectObjectAndDeprecatedReconnect(): void
+    {
+        $this->rpc->shouldReceive('call')
+            ->once()
+            ->withArgs(fn(
+                string $method,
+                DTO\DisconnectRequest $request,
+                string $responseClass
+            ): bool => $method === 'centrifuge.Unsubscribe'
+                && $request->getUser() === 'foo-user'
+                && $request->getClient() === 'foo-client'
+                && $request->getSession() === 'foo-session'
+                && $request->getDisconnect()->getCode() === 400
+                && $request->getDisconnect()->getReason() === 'foo-reason'
+                && $responseClass === DTO\DisconnectResponse::class
+            )
+            ->andReturn(new DTO\DisconnectResponse);
+
+        $this->api->disconnect(
+            user: 'foo-user',
+            client: 'foo-client',
+            session: 'foo-session',
+            disconnect: new Disconnect(code: 400, reason: 'foo-reason', reconnect: true),
+        );
     }
 }

--- a/tests/Unit/Request/AbstractRequestTest.php
+++ b/tests/Unit/Request/AbstractRequestTest.php
@@ -99,7 +99,7 @@ final class AbstractRequestTest extends TestCase
     {
         $worker = $this->createWorker(function (Payload $arg) {
             $expects = new Payload((new ConnectResponse())
-                ->setDisconnect(new Disconnect(['code' => 111, 'reason' => 'some', 'reconnect' => false]))
+                ->setDisconnect(new Disconnect(['code' => 111, 'reason' => 'some']))
                 ->serializeToString()
             );
 
@@ -115,11 +115,11 @@ final class AbstractRequestTest extends TestCase
         $req->disconnect(111, 'some');
     }
 
-    public function testDisconnectWithReconnect(): void
+    public function testDisconnectWithDeprecatedReconnect(): void
     {
         $worker = $this->createWorker(function (Payload $arg) {
             $expects = new Payload((new ConnectResponse())
-                ->setDisconnect(new Disconnect(['code' => 111, 'reason' => 'some', 'reconnect' => true]))
+                ->setDisconnect(new Disconnect(['code' => 111, 'reason' => 'some']))
                 ->serializeToString()
             );
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ✔️
| Breaks BC?    | ❌ 
| New feature?  | ❌


The **reconnect** parameter was removed in centrifugal/centrifugo v5.0.0:
https://centrifugal.dev/docs/getting-started/migration_v5

> reconnect flag removed from disconnect API call and proxy structures for custom disconnection

