### PR TITLE
Add support of google/protobuf v5.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "spiral/goridge": "^4.0",
         "spiral/roadrunner-worker": "^3.0",
         "spiral/roadrunner": "^2023.1 || ^2024.1 || ^2025.1",
-        "google/protobuf": "^3.7 || ^4.0"
+        "google/protobuf": "^3.7 || ^4.0 || ^5.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd" bootstrap="vendor/autoload.php"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd" bootstrap="tests/bootstrap.php"
          backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" stopOnError="false"
          stderr="true" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
     <coverage>

--- a/tests/Unit/RPCCentrifugoApiTest.php
+++ b/tests/Unit/RPCCentrifugoApiTest.php
@@ -46,7 +46,7 @@ final class RPCCentrifugoApiTest extends TestCase
                 && $request->getChannel() === 'foo-channel'
                 && $request->getData() === \json_encode(['foo' => 'bar'])
                 && $request->getSkipHistory() === true
-                && \iterator_to_array($request->getTags()->getIterator()) === ['baz', 'baf']
+                && self::tagsOf($request) === ['baz', 'baf']
                 && $responseClass === DTO\PublishResponse::class
             )
             ->andReturn(new DTO\PublishResponse);
@@ -124,5 +124,20 @@ final class RPCCentrifugoApiTest extends TestCase
             session: 'foo-session',
             disconnect: new Disconnect(code: 400, reason: 'foo-reason', reconnect: true),
         );
+    }
+
+    /**
+     * The iteration order of a protobuf `MapField` is an implementation detail of the runtime and differs
+     * between releases (google/protobuf 4.33 already yields the entries of a two-element map back to front),
+     * so compare the tags by key instead of by iteration order.
+     *
+     * @return array<array-key, string>
+     */
+    private static function tagsOf(DTO\PublishRequest $request): array
+    {
+        $tags = \iterator_to_array($request->getTags()->getIterator());
+        \ksort($tags);
+
+        return $tags;
     }
 }

--- a/tests/Unit/Request/ConnectTest.php
+++ b/tests/Unit/Request/ConnectTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace RoadRunner\Centrifugo\Tests\Unit\Request;
 
 use Google\Protobuf\Internal\MapField;
-use Google\Protobuf\Internal\RepeatedField;
+use Google\Protobuf\RepeatedField;
 use RoadRunner\Centrifugal\Proxy\DTO\V1\BoolValue;
 use RoadRunner\Centrifugal\Proxy\DTO\V1\ConnectResponse as ConnectResponseDTO;
 use RoadRunner\Centrifugal\Proxy\DTO\V1\ConnectResult;

--- a/tests/Unit/Request/SubscribeTest.php
+++ b/tests/Unit/Request/SubscribeTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace RoadRunner\Centrifugo\Tests\Unit\Request;
 
-use Google\Protobuf\Internal\RepeatedField;
+use Google\Protobuf\RepeatedField;
 use RoadRunner\Centrifugal\Proxy\DTO\V1\BoolValue;
 use RoadRunner\Centrifugal\Proxy\DTO\V1\SubscribeOptionOverride;
 use RoadRunner\Centrifugal\Proxy\DTO\V1\SubscribeResult;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+/**
+ * google/protobuf 4.x moved `RepeatedField` out of the `Internal` namespace into the public
+ * `Google\Protobuf` one and left a `class_alias()` for the old FQN at the bottom of the new file.
+ * That alias is only registered once the new class has been loaded, so autoloading the old FQN
+ * on its own fails. Tests therefore reference the public FQN, which we back-fill on protobuf 3.x.
+ *
+ * `MapField` has not been moved and still lives in `Google\Protobuf\Internal` in every version.
+ */
+if (!\class_exists(\Google\Protobuf\RepeatedField::class)) {
+    \class_alias(\Google\Protobuf\Internal\RepeatedField::class, \Google\Protobuf\RepeatedField::class);
+}


### PR DESCRIPTION
Allows `google/protobuf` 5.x, the same way #13 allowed 4.x — the constraint becomes
`^3.7 || ^4.0 || ^5.0`. No source change is needed: the DTOs come from
`roadrunner-php/roadrunner-api-dto`, which already requires
`google/protobuf: ^4.31.1 || ^5.34.0`, so this package's upper bound is the only thing that keeps
protobuf 5 out of an installation.

Why it matters downstream: `spiral/roadrunner-bridge` ^4.0 depends on this package, so an
application that wants the bridge together with `google/protobuf` 5.x cannot have both — Composer
either fails to resolve or downgrades protobuf to 4.x.

### The test commit

`RPCCentrifugoApiTest::testPublish` compares the publish tags with `===` against `['baz', 'baf']`,
which also compares key order. The iteration order of a protobuf `MapField` is an implementation
detail of the runtime and it changed: on `google/protobuf` 4.33 a two-entry map already iterates back
to front (`[1 => 'baf', 0 => 'baz']`), so the test fails there — **before** this constraint change,
on 4.x. The first commit sorts the entries by key so the assertion checks the tag values it means to
check. Without it CI on this branch would be red for a reason unrelated to protobuf 5.

### Verification

`php 8.4.23`, full suite green in both matrix legs CI uses:

| Leg | Resolved | Result |
|---|---|---|
| `prefer-stable` | `google/protobuf v5.35.1`, `api-dto v1.14.1` | 121 tests, 425 assertions — OK |
| `prefer-lowest` | `google/protobuf v4.33.6`, `api-dto v1.8.0` | 121 tests, 425 assertions — OK |

Note on the `static analysis` job: it is already failing on `2.x` independently of this PR. Psalm 6
(the `require-dev` constraint is `>= 5.8`) reports 48 `MissingOverrideAttribute` / `ClassMustBeFinal`
issues; the count is identical with and without this branch, so it is left alone here.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Compatibility**
  * Broadened supported Protocol Buffers versions, including Protobuf v5.x.

* **Bug Fixes**
  * Fixed publish request tag validation to be consistent regardless of tag ordering.

* **Tests**
  * Updated the test bootstrap process and added a Protobuf compatibility shim to keep unit tests working across different Protobuf runtime variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->